### PR TITLE
Fix bug where Slack API returns 400 due to large entities

### DIFF
--- a/generators/slack.py
+++ b/generators/slack.py
@@ -323,7 +323,7 @@ class SlackMessageGenerator(generators.base.BaseMessageGenerator):
             
             # we must account for the length of the level title
             # in the max size of a slack message block
-            MAX_MESSAGE_BLOCK_SIZE_FOR_TITLE = (
+            max_message_block_size_for_entities = (
                 SlackMessageGenerator.SLACK_MAX_MESSAGE_BLOCK_SIZE
                 - len(level_title)
             )
@@ -341,7 +341,7 @@ class SlackMessageGenerator(generators.base.BaseMessageGenerator):
                 text_length = 0
                 entities_text = ""
                 while text_length < (
-                    MAX_MESSAGE_BLOCK_SIZE_FOR_TITLE
+                    max_message_block_size_for_entities
                 ) and current_count < len(entities):
                     current_entities.append(entities[current_count])
                     entities_text = " \n".join(

--- a/generators/slack.py
+++ b/generators/slack.py
@@ -285,7 +285,11 @@ class SlackMessageGenerator(generators.base.BaseMessageGenerator):
             if not matched:
                 filtered_top_lowest_scored_rules_by_percentage.append((lowest_rule, value))
 
-        return top_3_highest_scored_rules_by_percentage, filtered_top_lowest_scored_rules_by_percentage
+        return (
+            top_3_highest_scored_rules_by_percentage,
+            filtered_top_lowest_scored_rules_by_percentage
+        )
+
 
     @staticmethod
     def _calculate_top_teams_by_percentage(entities: list,
@@ -301,7 +305,7 @@ class SlackMessageGenerator(generators.base.BaseMessageGenerator):
             for team, _ in sorted(entities_by_team.items(), key=lambda item: item[1], reverse=True)[:3]
         ]
         return top_3_teams_by_percentage
-    
+
     @staticmethod
     def _generate_entities_list_with_level_and_link(
         blueprint: str,

--- a/generators/slack.py
+++ b/generators/slack.py
@@ -10,7 +10,6 @@ class SlackMessageGenerator(generators.base.BaseMessageGenerator):
     # Slack has a limit of 3001 characters per message block
     # We will use this constant to split the message blocks into smaller ones
     SLACK_MAX_MESSAGE_BLOCK_SIZE = 3000
-    SCORECARD_ENTITIES_BATCH_SIZE = 20
 
     def scorecard_report(self, blueprint: str, scorecard: Dict[str, Any], entities: list):
         blueprint_plural = utils.convert_to_plural(blueprint).title()

--- a/utils.py
+++ b/utils.py
@@ -9,6 +9,7 @@ def convert_to_plural(word: str):
     plural_word = p.plural(word)
     return plural_word
 
+
 def batch_items(items: list[Any], batch_size: int):
     """
     Breaks the given list of items into batched lists with a preset length.
@@ -22,5 +23,5 @@ def batch_items(items: list[Any], batch_size: int):
 
     it = iter(items)
     batched_list = list(iter(lambda: list(itertools.islice(it, batch_size)), []))
-    
+
     return batched_list

--- a/utils.py
+++ b/utils.py
@@ -8,20 +8,3 @@ def convert_to_plural(word: str):
     p = inflect.engine()
     plural_word = p.plural(word)
     return plural_word
-
-
-def batch_items(items: list[Any], batch_size: int):
-    """
-    Breaks the given list of items into batched lists with a preset length.
-
-    :param items: List of items to be batched.
-    :param batch_size: Preset length of each batch.
-    :return: List of batched lists.
-    """
-    if batch_size <= 0:
-        raise ValueError("Batch size must be greater than 0")
-
-    it = iter(items)
-    batched_list = list(iter(lambda: list(itertools.islice(it, batch_size)), []))
-
-    return batched_list

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,3 @@
-import itertools
-from typing import Any
-
 import inflect
 
 

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,6 @@
+import itertools
+from typing import Any
+
 import inflect
 
 
@@ -5,3 +8,19 @@ def convert_to_plural(word: str):
     p = inflect.engine()
     plural_word = p.plural(word)
     return plural_word
+
+def batch_items(items: list[Any], batch_size: int):
+    """
+    Breaks the given list of items into batched lists with a preset length.
+
+    :param items: List of items to be batched.
+    :param batch_size: Preset length of each batch.
+    :return: List of batched lists.
+    """
+    if batch_size <= 0:
+        raise ValueError("Batch size must be greater than 0")
+
+    it = iter(items)
+    batched_list = list(iter(lambda: list(itertools.islice(it, batch_size)), []))
+    
+    return batched_list


### PR DESCRIPTION
When the number of repositories are large enough, the message generated overshoots the message limit per block for Slack's API. This causes a 400 error. To fix this, I implemented a functionality to automatically break them into chunks of 20 entities per block. A side effect is an extra space between chunks as seen in the image below:

![image](https://github.com/port-labs/port-sender/assets/33290249/697cdceb-a906-4fe4-b3d6-ac26a857670b)

Edit: I changed this to batch based on the length of the entities instead as there is no guarantee that the entities won't have names long enough to break the API again.
