### PR TITLE
Fix - Scorecard label for GitHub issue sync to be set from the scorecard identifier

### DIFF
--- a/generators/github.py
+++ b/generators/github.py
@@ -22,7 +22,7 @@ class GithubIssueGenerator(generators.base.BaseIssueGenerator):
             f"\n> :bulb: **Tip:** Scorecards are a way for you and your team to define and track standards, metrics, and KPIs in different categories such as production readiness, quality, productivity, and more. For more information about your scorecards, go to [Port]({get_port_url(settings.port_region)})"
             "\n# Sub-Tasks"
             "\n" + "\n".join(tasks) + "\n",
-            "labels": ["Port", scorecard_title, level, blueprint, entity["identifier"]],
+            "labels": ["Port", scorecard.get("identifier",""), level, blueprint, entity["identifier"]],
         }
 
     def generate_task(self, rule: dict[str, Any]):


### PR DESCRIPTION
Update label of a scorecard to be taken from the identifier rather then from the title of the scorecards